### PR TITLE
dhi-node with non-root user `node` by default

### DIFF
--- a/.devcontainer/dhi-node/Dockerfile
+++ b/.devcontainer/dhi-node/Dockerfile
@@ -4,3 +4,5 @@ FROM dhi.io/node:22-debian13-sfw-dev
 RUN apt-get update \
     && apt-get install -y gzip \
     && ldconfig
+
+USER nonroot

--- a/.devcontainer/dhi-node/Dockerfile
+++ b/.devcontainer/dhi-node/Dockerfile
@@ -5,4 +5,4 @@ RUN apt-get update \
     && apt-get install -y gzip \
     && ldconfig
 
-USER nonroot
+USER node

--- a/.devcontainer/dhi-node/devcontainer.json
+++ b/.devcontainer/dhi-node/devcontainer.json
@@ -3,6 +3,7 @@
     "dockerComposeFile": "compose.yaml",
     "service": "workspace",
     "workspaceFolder": "/workspace",
+	"remoteUser": "nonroot",
 	"containerEnv": {
 		"DOCKER_USERNAME": "${localEnv:DOCKER_USERNAME}",
 		"DOCKER_PASSWORD": "${localEnv:DOCKER_PASSWORD}"

--- a/.devcontainer/dhi-node/devcontainer.json
+++ b/.devcontainer/dhi-node/devcontainer.json
@@ -3,7 +3,7 @@
     "dockerComposeFile": "compose.yaml",
     "service": "workspace",
     "workspaceFolder": "/workspace",
-	"remoteUser": "nonroot",
+	"remoteUser": "node",
 	"containerEnv": {
 		"DOCKER_USERNAME": "${localEnv:DOCKER_USERNAME}",
 		"DOCKER_PASSWORD": "${localEnv:DOCKER_PASSWORD}"


### PR DESCRIPTION
<img width="419" height="149" alt="image" src="https://github.com/user-attachments/assets/dc03c39b-2041-4098-8785-34fcb2344ed4" />
